### PR TITLE
Upgrade nano version to get more info when 'Unspecified error' occurs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "node": ">= 0.6.14"
   },
   "dependencies": {
-    "request": "2.9.203",
-    "async" : "0.1.22",
-    "nano" : "3.1.0"
+    "request": "2.12.0",
+    "async": "0.1.22",
+    "nano": "3.3.3"
   },
   "devDependencies": {
-    "should" : "1.1.0",
-    "sandboxed-module" : "0.1.3",
-    "mocha": "1.3.2",
+    "should": "1.2.1",
+    "sandboxed-module": "0.1.3",
+    "mocha": "1.7.0",
     "express": "3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "should" : "1.1.0",
     "sandboxed-module" : "0.1.3",
-    "mocha": "1.3.2"
+    "mocha": "1.3.2",
+    "express": "3.0.3"
   }
 }


### PR DESCRIPTION
Nano 3.3.1 includes the fix to add more error info https://github.com/dscape/nano/issues/93 .
I need this to investigate an error when updating Stalka sequence in CouchDB.

Also upgraded all deps to latest greatest.
