### PR TITLE
Trigger statsWriter after creating a new sequence doc

### DIFF
--- a/lib/stalka.js
+++ b/lib/stalka.js
@@ -180,6 +180,9 @@ Stalka.prototype.readSequence = function(db, callback) {
       // creating a new sequence document when it does not exist is consistent to
       // the way CouchDB replicators tracking the last change sequence
       self.updateSequence(db, sequenceDoc, function (err, result) {
+        if (!err && self.statsWriter) {
+          self.statsWriter(sequenceDoc.lastSequence);
+        }
         callback(err, sequenceDoc);
       });
     } else {

--- a/test/stalka.js
+++ b/test/stalka.js
@@ -60,6 +60,25 @@ describe('Stalka', function() {
         done();
       });
     }),
+    it("should write lastSequence 0 stat when sequence document is not found", function(done) {
+      var db = { 
+        get: function(id, callback) { callback({status_code: 404}, null); },
+        insert: function(document, id, callback) {
+          id.should.equal("_local/feed");
+          callback();
+        }
+      };
+      var stalka = sandbox.require(libpath + '/stalka', {
+        requires: {'nano': fakenano, 'request': fakerequest}
+      });
+
+      stalka.registerStatsWriter(function (lastSequence) {
+        lastSequence.should.equal(0);
+        done();
+      });
+      stalka.readSequence(db, function(err, body) {
+      });
+    }),
     it("should return an error when an error occurs", function(done) {
       var db = { 
         get: function(id, callback) { callback("Failed to read sequence.", null); }


### PR DESCRIPTION
because otherwise stats will have a stale value while waiting for any change.

Problem scenario (before the patch):
- last sequence 500
- database deleted, _local/feed doc is gone
- stalka failed update, retried, and created a new sequence
- _local/feed last sequence: 0, but stats client still had 500
- stats on the client won't be corrected until there's a change notification
- the client didn't do anything that might update change notification due to last sequence 500
- both stalka and client wait for each other indefinitely

This patch fixes the above scenario.
