### PR TITLE
Publish start sequence prior to listening to changes + Add infinite retry

### DIFF
--- a/lib/stalka.js
+++ b/lib/stalka.js
@@ -46,6 +46,7 @@ Stalka.prototype.registerStatsWriter = function(statsWriter) {
 };
 
 Stalka.prototype.start = function (dbUri, changesWriter, options, mainCallback) {
+  var INFINITE_RETRY = -1;
   var self = this;
   options = options || {};
   var retryCount = options.retryCount || 0;
@@ -63,7 +64,7 @@ Stalka.prototype.start = function (dbUri, changesWriter, options, mainCallback) 
         err.message === 'Document update conflict.' ||
         err.message === 'no_db_file')) {
 
-      if (retryCount > maxRetryCount) {
+      if (maxRetryCount !== INFINITE_RETRY && retryCount > maxRetryCount) {
         console.log('Stop retrying - Max retry count %d', maxRetryCount);
         mainCallback(err);
       } else {

--- a/lib/stalka.js
+++ b/lib/stalka.js
@@ -101,6 +101,9 @@ Stalka.prototype._start = function(dbUri, changesWriter, options, mainCallback) 
       console.error("Unable to read sequence.", err.message);
       mainCallback(err);
       return;
+    } else if (self.statsWriter) {
+      console.log("Publish initial sequence: " + startSequence);
+      self.statsWriter(startSequence);
     }
 
     async.whilst(

--- a/test/stalka.js
+++ b/test/stalka.js
@@ -495,6 +495,10 @@ describe('Stalka', function() {
       });
     }),
     it("should continue processing when theres an invalid changes body", function(done) {
+      var statsSequence;
+      stalka.statsWriter = function (sequence) {
+        statsSequence = sequence;
+      };
       stalka.readSequence = function(db, callback) {
         callback(null, {lastSequence: 123});
       };
@@ -507,6 +511,7 @@ describe('Stalka', function() {
       }, null, function(err) {
         done();
       });
+      statsSequence.should.equal(123);
     });
   });
 });


### PR DESCRIPTION
## Publish start sequence prior to listening to changes

When last sequence in _local/feed is N and Stalka is started, Stalka will start polling since N but statsWriter registrars will have sequence 0. This inconsistent value will stay until there's a change, which might take a while for a non-write-heavy instance.
This patch should ensure that both Stalka and statsWriter registrars start with the same sequence.
## Add infinite retry

This patch allows Stalka to keep retrying during a long duration of errors (e.g. couch is down for several hours). Without infinite retry, Stalka will have to be restarted, and probably involve some form of manual intervention.
